### PR TITLE
fix: run test files directly in "__tests__"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
       "title": "List of scopes to run Jest on.",
       "type": "array",
       "default": [
+        "**/__tests__/*.js",
+        "**/__tests__/*.jsx",
+        "**/__tests__/*.ts",
+        "**/__tests__/*.tsx"
         "**/__tests__/**/*.js",
         "**/__tests__/**/*.jsx",
         "**/__tests__/**/*.ts",


### PR DESCRIPTION
Hello yacut,

Thanks for this great package!

Fix description:
I noticed "tester-jest" was not running tests within "__tests__/foo.js", so I updated default scopes to include files directly within "__tests__".

